### PR TITLE
Fix: Missing `babel-eslint` dep 1.0.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ package-lock.json
 db/*
 build/
 tags
+.undodir/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+# 1.0.5
+- fix: add missing babel-eslint dep needed for external builds to succeed
+- meta: bump react-scripts
+
 # 1.0.4
 - fix: transform commonjs modules in babel config
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bfx-hf-chart",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "HF Financial Charting Library",
   "main": "dist/components/Chart/Chart.js",
   "author": "Bitfinex",
@@ -27,7 +27,7 @@
     "react-custom-scrollbars": "^4.2.1",
     "react-dom": "^16.12.0",
     "react-onclickoutside": "^6.9.0",
-    "react-scripts": "3.3.0"
+    "react-scripts": "3.4.1"
   },
   "scripts": {
     "cra-build": "react-scripts build",
@@ -64,6 +64,7 @@
     "@babel/core": "^7.7.5",
     "@babel/plugin-transform-react-jsx": "^7.7.4",
     "babel-core": "^6.26.3",
+    "babel-eslint": "^10.1.0",
     "babel-plugin-transform-es2015-modules-commonjs": "^6.26.2",
     "eslint": "^6.7.2",
     "eslint-config-airbnb": "^18.0.1",


### PR DESCRIPTION
External builds (i.e. installed as a submodule) seem to require babel-eslint as a dep now; `react-scripts` complains that the available version is out of date.

* NOTE: Bumped `react-scripts`